### PR TITLE
Bugfix for balance call returning bad request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,8 @@ class MonzoApi {
      *                                   or an Error if rejected.
      */
     balance(accountId, accessToken) {
-        return this.makeRequest('GET', 'balance', { account_id: accountId }, true, accessToken);
+        const query = {account_id: accountId};
+        return this.makeRequest('GET', `balance?${qs.stringify(query)}`, false, true, accessToken);
     }
 
     /**


### PR DESCRIPTION
The monzo api balance endpoint takes the account id as a query string parameter. (https://monzo.com/docs/#balance)

Changed to send account_id with query string to stop 400 bad request errors when calling the balance function. 