### PR TITLE
List Transaction call needs account_id query parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -331,6 +331,8 @@ class MonzoApi {
      *                                   or an Error if rejected.
      */
     transactions(accountId, expanded = false, query = {}, accessToken) {
+    	query.account_id = accountId;
+    	
         if (expanded) {
             query['expand[]'] = 'merchant';
         }


### PR DESCRIPTION
Sorry for the 2nd one today!

The list transaction function was missing the account_id param from the query string, it causes a bad request error. 